### PR TITLE
Added support for 3D coordinates

### DIFF
--- a/src/main/java/com/scaleset/geo/geojson/GeometryDeserializer.java
+++ b/src/main/java/com/scaleset/geo/geojson/GeometryDeserializer.java
@@ -118,13 +118,13 @@ public class GeometryDeserializer<T extends Geometry> extends JsonDeserializer<T
     }
 
     Coordinate toCoordinate(ArrayNode node) {
-        double x = 0, y = 0, z = 0;
+        double x = 0, y = 0, z = Double.NaN;
         if (node.size() > 1) {
             x = node.get(0).asDouble();
             y = node.get(1).asDouble();
         }
         if (node.size() > 2) {
-            z = node.get(1).asDouble();
+            z = node.get(2).asDouble();
         }
         Coordinate result = new Coordinate(x, y, z);
         return result;

--- a/src/main/java/com/scaleset/geo/geojson/GeometrySerializer.java
+++ b/src/main/java/com/scaleset/geo/geojson/GeometrySerializer.java
@@ -125,6 +125,9 @@ public class GeometrySerializer extends JsonSerializer<Geometry> {
         gen.writeStartArray();
         gen.writeNumber(coordinate.x);
         gen.writeNumber(coordinate.y);
+        if (! Double.isNaN(coordinate.z)) {
+            gen.writeNumber(coordinate.z);
+        }
         gen.writeEndArray();
     }
 

--- a/src/test/java/com/scaleset/geo/geojson/GeoJsonModuleTest.java
+++ b/src/test/java/com/scaleset/geo/geojson/GeoJsonModuleTest.java
@@ -24,6 +24,14 @@ public class GeoJsonModuleTest extends Assert {
         assertEquals("{\"type\":\"Point\",\"coordinates\":[-78.0,39.0]}", json);
         Point p2 = mapper.readValue(json, Point.class);
         assertEquals(point, p2);
+        assertTrue(point.getCoordinate().equals3D(p2.getCoordinate()));
+        
+        point = factory.createPoint(new Coordinate(24, -56, 78));
+        json = mapper.writeValueAsString(point);
+        assertEquals("{\"type\":\"Point\",\"coordinates\":[24.0,-56.0,78.0]}", json);
+        p2 = mapper.readValue(json, Point.class);
+        assertEquals(point, p2);
+        assertTrue(point.getCoordinate().equals3D(p2.getCoordinate()));
     }
 
     @Test


### PR DESCRIPTION
Updated GeoJson classes to support coordinates with elevation. The JTS convention is to set the z coordinate to NaN if it is unused instead of 0 to distinguish between 3d coordinates and those with a zero elevation.
